### PR TITLE
hides old lesson guide

### DIFF
--- a/_episodes/01-design.md
+++ b/_episodes/01-design.md
@@ -4,6 +4,8 @@ redirect_to:
 - https://carpentries.github.io/curriculum-development/
 questions:
 - "How do we design lessons?"
+hidden: True
+
 ---
 
 Visit our [new curriculum development guide](https://carpentries.github.io/curriculum-development/).

--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -15,6 +15,8 @@
   {% endfor %}
   {% assign current = site.start_time %}
 
+
+
   <table class="table table-striped">
   <tr>
     {% if multiday %}<td class="col-md-1"></td>{% endif %}
@@ -22,7 +24,11 @@
     <td class="col-md-3"><a href="{{ relative_root_path }}{% link setup.md %}">Setup</a></td>
     <td class="col-md-7">Download files required for the lesson</td>
   </tr>
+
   {% for episode in site.episodes %}
+
+    {% unless episode.hidden %}
+
     {% if episode.start %} {% comment %} Starting a new day? {% endcomment %}
       {% assign day = day | plus: 1 %}
       {% if day > 1 %} {% comment %} If about to start day 2 or later, show finishing time for previous day {% endcomment %}
@@ -62,6 +68,9 @@
       </td>
     </tr>
     {% assign current = current | plus: episode.teaching | plus: episode.exercises | plus: episode.break %}
+
+   {% endunless %}
+   
   {% endfor %}
   {% assign hours = current | divided_by: 60 %}
   {% assign minutes = current | modulo: 60 %}
@@ -72,6 +81,7 @@
     <td class="col-md-7"></td>
   </tr>
   </table>
+
 
   <p>
     The actual schedule may vary slightly depending on the topics and exercises chosen by the instructor.


### PR DESCRIPTION
The lesson example page (http://carpentries.github.io/lesson-example/) included a section on Lesson Design.  This is deprecated in favor of the new Curriculum Development Handbook (https://carpentries.github.io/curriculum-development/).

This PR hides the Lesson Design from the Lesson Example site, while keeping the placeholder link to allow it to redirect to the new CDH.  The CDH is also linked to in the top paragraph of the lesson Example page. 
