### PR TITLE
Add spellchecking to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,12 @@ env:
 jobs:
   include:
     - stage: spelling
+      language: python
+      sudo: true
+      python: "3.6"
       # The default before_install step is slow
       before_install:
       # Use codespell for spell checking
       install:
-        sudo -H pip3 install codespell
+        sudo pip install codespell
       script: codespell --skip="assets,fig,*.svg,AUTHORS,.mailmap" --quiet-level=2 --ignore-words-list="rouge"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,5 @@ jobs:
       before_install:
       # Use codespell for spell checking
       install:
-        pip install codespell
+        sudo -H pip3 install codespell
       script: codespell --skip="assets,fig,*.svg,AUTHORS,.mailmap" --quiet-level=2 --ignore-words-list="rouge"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ jobs:
       # Use codespell for spell checking
       install:
         sudo pip install codespell
-      script: codespell --skip="assets,fig,*.svg,AUTHORS,.mailmap" --quiet-level=2 --ignore-words-list="rouge"
+      script: codespell --skip="assets,fig,*.svg,AUTHORS,.mailmap" --quiet-level=2 --ignore-words-list="rouge,keyserver"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,4 @@ jobs:
       install:
         sudo pip install codespell
       script: codespell --skip="assets,fig,*.svg,AUTHORS,.mailmap" --quiet-level=2 --ignore-words-list="rouge,keyserver"
+    - stage: check_and_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,14 @@ env:
   global:
   - _R_CHECK_FORCE_SUGGESTS_=false
   #- MAKEFLAGS="-j 2"
+
+# Add spellchecking for PRs
+jobs:
+  include:
+    - stage: spelling
+      # The default before_install step is slow
+      before_install:
+      # Use codespell for spell checking
+      install:
+        pip install codespell
+      script: codespell --skip="assets,fig,*.svg,AUTHORS,.mailmap" --quiet-level=2 --ignore-words-list="rouge"

--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -38,7 +38,7 @@ Limit all lines to a maximum of 100 characters.
 `bin/lesson_check.py` will report lines longer than 100 characters
 and this can block your contributions of being accepted.
 
-The two reasons behind the decision to enforce a maximum line lenght are
+The two reasons behind the decision to enforce a maximum line length are
 (1) make diff and merge easier in the command line and other user interfaces
 and
 (2) make update of translation of the lessons easier.

--- a/bin/boilerplate/.travis.yml
+++ b/bin/boilerplate/.travis.yml
@@ -21,3 +21,17 @@ install:
 script:
   - make lesson-check-all
   - make --always-make site
+# Add spellchecking for PRs
+jobs:
+  include:
+    - stage: spelling
+      language: python
+      sudo: true
+      python: "3.6"
+      # The default before_install step is slow
+      before_install:
+      # Use codespell for spell checking
+      install:
+        sudo pip install codespell
+      script: codespell --skip="assets,fig,*.svg,AUTHORS,.mailmap" --quiet-level=2 --ignore-words-list="rouge,keyserver"
+    - stage: check

--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -13,7 +13,7 @@ generate_md_episodes <- function() {
   required_pkgs <- unique(c(
     ## Packages for episodes
     requirements:::req_dir("_episodes_rmd"),
-    ## Pacakges for tools
+    ## Packages for tools
     requirements:::req_dir("bin")
   ))
 

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -259,7 +259,7 @@ def check_fileset(source_dir, reporter, filenames_present):
     for m in missing:
         reporter.add(None, 'Missing required file {0}', m)
 
-    # Check episode files' names.
+    # Check names of episode files.
     seen = []
     for filename in filenames_present:
         if '_episodes' not in filename:

--- a/bin/repo_check.py
+++ b/bin/repo_check.py
@@ -147,7 +147,7 @@ def check_labels(reporter, repo_url):
     for name in sorted(overlap):
         reporter.check(EXPECTED[name].lower() == actual[name].lower(),
                        None,
-                       'Color mis-match for label {0} in {1}: expected {2}, found {3}',
+                       'Color mismatch for label {0} in {1}: expected {2}, found {3}',
                        name, repo_url, EXPECTED[name], actual[name])
 
 


### PR DESCRIPTION
It's possible to add spellchecking to your travis configuration with something like
```
jobs:
  include:
    - stage: spelling
      # The default before_install step is slow
      before_install:
      # Use codespell for spell checking
      install:
        pip install codespell
      script: codespell --skip="assets,fig,*.svg,AUTHORS,.mailmap" --quiet-level=2 --ignore-words-list="rouge"
```

This PR does that and corrects the typos that `codespell` found.
