### PR TITLE
SWC Syllabus: fix lesson names

### DIFF
--- a/_includes/sc/syllabus.html
+++ b/_includes/sc/syllabus.html
@@ -12,7 +12,7 @@
     </ul>
   </div>
   <div class="col-md-6">
-    <h3 id="syllabus-python">Programming in Python</h3>
+    <h3 id="syllabus-python">Programming with Python</h3>
     <ul>
       <li>Using libraries</li>
       <li>Working with arrays</li>
@@ -40,7 +40,7 @@
   -->
   <!--
   <div class="col-md-6">
-    <h3 id="syllabus-r">Programming in R</h3>
+    <h3 id="syllabus-r">Programming with R</h3>
     <ul>
       <li>Working with vectors and data frames</li>
       <li>Reading and plotting data</li>
@@ -53,7 +53,7 @@
   -->
   <!--
   <div class="col-md-6">
-    <h3 id="syllabus-matlab">Programming in MATLAB</h3>
+    <h3 id="syllabus-matlab">Programming with MATLAB</h3>
     <ul>
       <li>Working with arrays</li>
       <li>Reading and plotting data</li>
@@ -83,7 +83,7 @@
   </div>
   <!--
   <div class="col-md-6">
-    <h3 id="syllabus-sql">Managing Data with SQL</h3>
+    <h3 id="syllabus-sql">Databases and SQL</h3>
     <ul>
       <li>Reading and sorting data</li>
       <li>Filtering with <code>where</code></li>


### PR DESCRIPTION
Fixing inaccurate names of some SWC lessons in the Syllabus.