### PR TITLE
SWC Syllabus: remove OpenRefine

### DIFF
--- a/_includes/sc/syllabus.html
+++ b/_includes/sc/syllabus.html
@@ -83,14 +83,4 @@
     </ul>
   </div>
    -->
-  <div class="col-md-6">
-    <h3 id="syllabus-r">Open Refine</h3>
-    <ul>
-      <li>Introduction to OpenRefine</li>
-      <li>Importing data</li>
-      <li>Basic functions</li>
-      <li>Advanced Functions</li>
-      <li><a href="{{site.lc_pages}}library-openrefine/reference">Reference...</a></li>
-    </ul>
-  </div>
 </div>


### PR DESCRIPTION
OpenRefine is not part of the Software Carpentry but of the Library
Carpentry. Just cleaning up.

---