### PR TITLE
SWC Syllabus: add Python Gapminder lesson

### DIFF
--- a/_includes/sc/syllabus.html
+++ b/_includes/sc/syllabus.html
@@ -26,6 +26,20 @@
   </div>
   <!--
   <div class="col-md-6">
+    <h3 id="syllabus-python">Plotting and Programming in Python</h3>
+    <ul>
+      <li>Working with different data types</li>
+      <li>Writing functions</li>
+      <li>Using libraries</li>
+      <li>Reading and plotting data</li>
+      <li>Loops and conditionals</li>
+      <li>Useful practices when working with Python</li>
+      <li><a href="{{site.swc_pages}}/python-novice-gapminder/reference/">Reference...</a></li>
+    </ul>
+  </div>
+  -->
+  <!--
+  <div class="col-md-6">
     <h3 id="syllabus-r">Programming in R</h3>
     <ul>
       <li>Working with vectors and data frames</li>


### PR DESCRIPTION
Unless I miss something, I don't see Python Gapminder lesson in the SWC
syllabus... So, I'm adding it here.