### PR TITLE
05-rmarkdown-example.md: fix instructions for lessons in R-markdown

### DIFF
--- a/_episodes/05-rmarkdown-example.md
+++ b/_episodes/05-rmarkdown-example.md
@@ -32,9 +32,11 @@ each episode written in RMarkdown.
 
 
 ~~~
+```{r, eval = TRUE}
 source("../bin/chunk-options.R")
+```
 ~~~
-{: .language-r}
+{: .code}
 
 The rest of the lesson should be written as a normal RMarkdown file. You can
 include chunk for codes, just like you'd normally do.


### PR DESCRIPTION
Every episode of a Carpentries lesson written in R-markdown has to have the following block
right after the front matter:

~~~
```{r, eval = TRUE}
source("../bin/chunk-options.R")
```
~~~

Currently, this block itself is written using syntax for
non-R-markdown-based lesson, so lesson creators working with R-markdown are
supposed to know/remember two components:

1. Opening part: ```{r, eval = TRUE}
2. Closing part: ```
