### PR TITLE
Create New Lesson with git clone, avoiding github import

### DIFF
--- a/_episodes/02-tooling.md
+++ b/_episodes/02-tooling.md
@@ -41,7 +41,8 @@ and each author's working copy would be a fork of that master:
 However, GitHub only allows a user to have one fork of any particular repo.
 This creates a problem for us because an author may be involved in writing several lessons,
 each with its own repo.
-We therefore use [GitHub Importer][github-importer] to create new lessons.
+We therefore create new lessons by cloning, then we manually set the remote to a newly
+created and named empty repository.
 After the lesson has been created,
 we manually add the [template repository]({{ site.template_repo }}) as a remote called `template`
 to update the lesson when the template changes.

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ please see [the setup instructions]({{ page.root }}{% link setup.md %}).
 > ## Ten Things You Need To Know
 >
 > 0.  Don't panic.
-> 1.  Create a new lesson by cloning into an empty GitHub repository, *not* by forking.
+> 1.  Create a new lesson by creating a new, empty, repository, and populating it by pushing a clone of the `styles` repository, *not* by forking.
 > 2.  Run `bin/lesson_initialize.py` *once* in a new lesson repository to set up standard files.
 > 3.  Run `make lesson-check` to check that the lesson is formatted correctly.
 > 4.  Put lesson episodes in `_episodes` (or `_episodes_rmd` if you are writing in RMarkdown).

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ For guidelines on how to develop curriculum content, please visit [The Carpentri
 
 This lesson shows how to use [The Carpentries]({{ site.carpentries_site}})
 lesson template. The materials below assume familiarity with tools such as GitHub, Markdown, and Jekyll. For more guidance, please visit the [Technological introductions](https://carpentries.github.io/curriculum-development/technological-introductions.html) section of The Carpentries Curriculum Development Handbook.
-   
+
 For guidelines on how to help improve our lessons and this template,
 please see [the contribution guidelines][contributing];
 for guidelines on how to set up your machine to preview changes locally,
@@ -24,7 +24,7 @@ please see [the setup instructions]({{ page.root }}{% link setup.md %}).
 > ## Ten Things You Need To Know
 >
 > 0.  Don't panic.
-> 1.  Create a new lesson by using GitHub Import, *not* by forking.
+> 1.  Create a new lesson by cloning into an empty GitHub repository, *not* by forking.
 > 2.  Run `bin/lesson_initialize.py` *once* in a new lesson repository to set up standard files.
 > 3.  Run `make lesson-check` to check that the lesson is formatted correctly.
 > 4.  Put lesson episodes in `_episodes` (or `_episodes_rmd` if you are writing in RMarkdown).

--- a/setup.md
+++ b/setup.md
@@ -354,7 +354,8 @@ account. The effect is like a GitHub Fork, but not connected to the upstream cha
     ~~~
     {: .language-bash}
 
-    *QUESTION:* Should we then commit these
+    *QUESTION:* Do we need to add, commit, push these files? Or edit them all first?
+    This step needs a commit clarifying this.
 
 12. Create and edit files as explained further in
     [the episodes of this lesson]({{ page.root }}{% link index.md %}#schedule).

--- a/setup.md
+++ b/setup.md
@@ -288,7 +288,7 @@ account. The effect is like a GitHub Fork, but not connected to the upstream cha
     $ git clone -b gh-pages https://github.com/carpentries/styles.git data-cleanup
     ~~~
     {: .language-bash}
-    Do not use the URL of *this* repository,
+    Do not use the URL of *this* repository (https://github.com/carpentries/lesson-example),
     as that will bring in a lot of example files you don't actually want.
 
 7.  Go into your new local directory using:
@@ -301,7 +301,7 @@ account. The effect is like a GitHub Fork, but not connected to the upstream cha
     Note that in this and the previous step, the name of your directory should
     be what you named your lesson; on the example this is `data-cleanup`.
 
-8.  Link the local directory you just created with the Github repository you started with,
+8.  Link the local directory you just created with the new Github repository you created,
 
     ~~~
     $ git remote set-url origin https://github.com/timtomch/data-cleanup.git

--- a/setup.md
+++ b/setup.md
@@ -264,54 +264,54 @@ you will need the [PyYAML][pyyaml] module for Python 3.
 ## Creating a New Lesson
 
 We will assume that your user ID is `timtomch` and the name of your
-new lesson is `data-cleanup`.
+new lesson is `data-cleanup`. We'll use git to make a copy of this repo in your own GitHub
+account. The effect is like a GitHub Fork, but not connected to the upstream changes.
 
-1.  We'll use the [GitHub's importer][importer] to make a copy of this repo in your own GitHub
-    account. (Note: This is like a GitHub Fork, but not connected to the upstream changes)
+1.  Create an empty repo on GitHub, using [GitHub's new repository tool][new]
+    to go to the  the "Create new repository" page.
 
-2.  Put the URL of **[the styles repository][styles]**, that is
-    **https://github.com/carpentries/styles** in the "Your old repository’s clone URL" box.
-    Do not use the URL of this repository,
-    as that will bring in a lot of example files you don't actually want.
-
-3.  Select the owner for your new repository.
+2.  Select the owner for your new repository.
     In our example this is `timtomch`,
     but it may instead be an organization you belong to.
 
-4.  Choose a name for your lesson repository.
+3.  Choose a name for your lesson repository.
     In our example, this is `data-cleanup`.
 
-5.  Make sure the repository is public.
+5.  Make sure the repository is public. Don't initialize any files,
+    i.e. leave boxes unchecked at the bottom of that page.
+    Then, click on the green "Create repository" button to create the repository.
 
-6.  At this point, you should have a page like this:
-
-    ![]({{ page.root }}/fig/using-github-import.png)
-
-    You can now click "Begin Import".
-    When the process is done,
-    you can click "Continue to repository" to visit your newly-created repository.
-
-    Through the Github interface you can begin to edit and
-
-7.  If you want to work on the lesson from your local machine, you can
-    now clone your newly-created repository to your computer:
-
+6.  Clone the **[the styles repository][styles]**, that is
+    **https://github.com/carpentries/styles** to a local directory called `data-cleanup`,
+    using a bash shell to run the command:
     ~~~
-    $ git clone -b gh-pages https://github.com/timtomch/data-cleanup.git
+    $ git clone -b gh-pages https://github.com/carpentries/styles.git data-cleanup
     ~~~
     {: .language-bash}
+    Do not use the URL of *this* repository,
+    as that will bring in a lot of example files you don't actually want.
 
-    Note that the URL for your lesson will have your username and chosen repository name.
-
-8.  Go into that directory using:
+7.  Go into your new local directory using:
 
     ~~~
     $ cd data-cleanup
     ~~~
     {: .language-bash}
 
-    Note that the name of your directory should be what you named your lesson
-    on the example this is `data-cleanup`.
+    Note that in this and the previous step, the name of your directory should
+    be what you named your lesson; on the example this is `data-cleanup`.
+
+8.  Link the local directory you just created with the Github repository you started with,
+
+    ~~~
+    $ git remote set-url origin https://github.com/timtomch/data-cleanup.git
+    $ git push origin gh-pages
+    ~~~
+    {: .language-bash}
+
+    Again, the name of the remote should be `<username>/<mylesson>`, your username
+    followed by what you named your lesson; on the example this is
+    `timtomch/data-cleanup`. You can check that this has worked by refreshing the webpage from step 5, e.g. `https://github.com/timtomch/data-cleanup`.
 
 9. To be able to pull upstream style changes, you should manually add the
      styles repository as a remote called `template`:
@@ -340,16 +340,21 @@ new lesson is `data-cleanup`.
     ~~~
     {: .language-bash}
 
-	This will ensure that you are using the most "stable" version of the
-	template repository. Since it's being actively maintained by the
-	Software Carpentry community, you could end up using a development branch
-	that contains experimental (and potentially not working) features without
-	necessarily realising it. Switching to the `gh-branch` ensures you are
-	using the "stable" version of the template.
+    This will ensure that you are using the most "stable" version of the
+    template repository. Since it's being actively maintained by The
+    Carpentries community, you could end up using a development branch
+    that contains experimental (and potentially not working) features without
+    necessarily realising it. Switching to the `gh-pages` branch ensures you are
+    using the "stable" version of the template.
 
-11. Run `bin/lesson_initialize.py` to create all of the boilerplate files
-    that cannot be put into the styles repository
-    (because they would trigger repeated merge conflicts).
+11. Create all of the boilerplate files that cannot be put into the styles repository
+    (because they would trigger repeated merge conflicts), by running:
+    ~~~
+    $ python bin/lesson_initialize.py
+    ~~~
+    {: .language-bash}
+
+    *QUESTION:* Should we then commit these
 
 12. Create and edit files as explained further in
     [the episodes of this lesson]({{ page.root }}{% link index.md %}#schedule).

--- a/setup.md
+++ b/setup.md
@@ -267,7 +267,7 @@ We will assume that your user ID is `timtomch` and the name of your
 new lesson is `data-cleanup`. We'll use git to make a copy of this repo in your own GitHub
 account. The effect is like a GitHub Fork, but not connected to the upstream changes.
 
-1.  Create an empty repo on GitHub, using [GitHub's new repository tool][new]
+1.  Create an empty repo on GitHub, using [GitHub's new repository tool](new)
     to go to the  the "Create new repository" page.
 
 2.  Select the owner for your new repository.


### PR DESCRIPTION
Edits `setup.md` "Creating a New Lesson" section, to describe how to set up a new lesson into an empty github repository by cloning styles into a local repository. This is the approach suggested by @maxim-belkin in [styles#505](/carpentries/styles/issues/505); this pull request should address [styles#505](/carpentries/styles/issues/505) (github import fails), by avoiding github import entirely.

I have tested this, request review from @fmichonneau.