### PR TITLE
correct class for HTML syntax highlighting

### DIFF
--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -173,7 +173,7 @@ echo "Hello World"
 ~~~
 {: .language-bash}
 
-`.html`: HTML source:
+`.language-html`: HTML source:
 
 ~~~
 <html>
@@ -182,7 +182,7 @@ echo "Hello World"
 </body>
 </html>
 ~~~
-{: .html}
+{: .language-html}
 
 `.language-make`: Makefiles:
 


### PR DESCRIPTION
`{: .html}` -> `{: .language-html}`