### PR TITLE
Document syntax highlighting for non-core languages

### DIFF
--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -250,26 +250,6 @@ RETURN (0)
 > ~~~
 > {: .language-yaml }
 >
-> and combining `.language-*` with the `.source` class with add the generic
-> "Code" title to the block.
->
-> {% raw %}
->     ~~~
->     for i = 1:2, j = 3:4
->         println((i, j))
->         i = 0
->     end
->     ~~~
->     {: .source .language-julia }
-> {% endraw %}
->
-> ~~~
-> for i = 1:2, j = 3:4
->     println((i, j))
->     i = 0
-> end
-> ~~~
-> {: .source .language-julia }
 >
 > Note that using `.language-*` classes other than
 > `.language-bash`

--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -222,6 +222,68 @@ RETURN (0)
 ~~~
 {: .language-sql}
 
+> ## Highlighting for other languages
+> You may use other `language-*` classes to activate syntax highlighting
+> for other languages.
+> For example,
+>
+> {% raw %}
+>     ~~~
+>     title: "YAML Highlighting Example"
+>     description: "This is an example of syntax highlighting for YAML."
+>     array_values:
+>         - value_1
+>         - value_2
+>     ~~~
+>     {: .language-yaml }
+> {% endraw %}
+>
+>
+> will produce this:
+>
+> ~~~
+> title: "YAML Highlighting Example"
+> description: "This is an example of syntax highlighting for YAML."
+> array_values:
+>     - value_1
+>     - value_2
+> ~~~
+> {: .language-yaml }
+>
+> and combining `.language-*` with the `.source` class with add the generic
+> "Code" title to the block.
+>
+> {% raw %}
+>     ~~~
+>     for i = 1:2, j = 3:4
+>         println((i, j))
+>         i = 0
+>     end
+>     ~~~
+>     {: .source .language-julia }
+> {% endraw %}
+>
+> ~~~
+> for i = 1:2, j = 3:4
+>     println((i, j))
+>     i = 0
+> end
+> ~~~
+> {: .source .language-julia }
+>
+> Note that using `.language-*` classes other than
+> `.language-bash`
+> `.language-html`,
+> `.language-make`,
+> `.language-matlab`,
+> `.language-python`,
+> `.language-r`,
+> or `.language-sql`
+> will currently cause one of the tests in the lesson template's
+> `make lesson-check` to fail for your lesson,
+> but will not prevent lesson pages from building and rendering correctly.
+>
+{: .solution }
 
 
 ## Special Blockquotes


### PR DESCRIPTION
As the number of lessons in The Carpentries Incubator increases, there is a growing need to provide code examples beyond the core languages traditionally taught in The Carpentries. Rouge and kramdown allow for syntax highlighting of most languages, but the lesson template isn't fully compatible with languages other than Bash, HTML, Make, MATLAB, Python, R, and SQL. Nevertheless, I think it is important that the lesson developers can read in the Lesson Example about how to activate highlighting of other languages. 

This PR adds an expandable box providing information about how to activate syntax highlighting for blocks of code in languages other than those listed above.