### PR TITLE
Allow building lesson and deploying to GitLab Pages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,18 @@
+image:
+  name: carpentries/lesson-docker:latest
+  entrypoint: [""]
+
+variables:
+  LC_ALL: "C.UTF-8"
+  MAKEFLAGS: "-j 8"
+
+pages:
+  stage: deploy
+  script:
+      - make site
+      - mv _site public
+  artifacts:
+      paths:
+          - public
+  only:
+      - gh-pages


### PR DESCRIPTION
This commit adds a `.gitlab-ci.yml` file that allows building the lesson on GitLab and deploying to GitLab Pages.

GitLab is an alternative to GitHub that supports "on-premise" installation, making it a popular choice for many organizations.