### PR TITLE
include a blank line between example header and content

### DIFF
--- a/_episodes/02-tooling.md
+++ b/_episodes/02-tooling.md
@@ -97,6 +97,7 @@ It looks for text files that begin with a header formatted like this:
 variable: value
 other_variable: other_value
 ---
+
 ...stuff in the page...
 ~~~
 {: .source}


### PR DESCRIPTION
Users often run into trouble when forgetting to leave a blank line between the closing `---` of the page front matter and the beginning of the page content. To reduce confusion, this PR updates the example code block to include a blank line. 