### PR TITLE
import link

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -12,7 +12,7 @@
 [cran-stringr]: https://cran.r-project.org/package=stringr
 [dc-lessons]: http://www.datacarpentry.org/lessons/
 [email]: mailto:team@carpentries.org
-[github-importer]: https://import.github.com/
+[github-importer]: https://import2.github.com/
 [importer]: https://github.com/new/import
 [jekyll-collection]: https://jekyllrb.com/docs/collections/
 [jekyll-install]: https://jekyllrb.com/docs/installation/


### PR DESCRIPTION
I don't know what `import.github.com` used to look like but now it looks like this:

![import](https://user-images.githubusercontent.com/10779688/114792122-a9328580-9d7f-11eb-819f-70ed7efd65d0.png)

import2 redirects to `https://github.com/new/import` which is at least a viewable webpage