### PR TITLE
05-rmarkdown-example.Rmd: ignore renv in the 'Can you do it?' challenge

### DIFF
--- a/_episodes_rmd/05-rmarkdown-example.Rmd
+++ b/_episodes_rmd/05-rmarkdown-example.Rmd
@@ -183,7 +183,7 @@ will generate this:
 >
 > > ## Solution
 > >
-> > ```{r, echo=FALSE}
+> > ```{r, echo=FALSE, renv.ignore=TRUE}
 > > paste("This", "new", "template", "looks", "good")
 > > ```
 > {: .solution}


### PR DESCRIPTION
This is to suppress the `ERROR 1: <text>:187:1: unexpected '>'` error
message reported in carpentries/lesson-example#341
