### PR TITLE
Typo: missing verb

### DIFF
--- a/_episodes/04-formatting.md
+++ b/_episodes/04-formatting.md
@@ -274,7 +274,7 @@ We use blockquotes to group headings and text
 rather than wrapping them in `div` elements.
 in order to avoid confusing [Jekyll][jekyll]'s parser
 (which sometimes has trouble with Markdown inside HTML).
-Each special blockquote must started with a level-2 header,
+Each special blockquote must begin with a level-2 header,
 but may contain anything after that.
 For example,
 a callout is formatted like this:


### PR DESCRIPTION
#### Problem

The sentence _Each special blockquote must started with a level-2 header_ is grammatically incorrect.

#### Solution

I propose using _Each special blockquote must begin with a level-2 header_ instead.

Other possibilities are:

- _Each special blockquote must be started with a level-2 header_.
- _Each special blockquote must start with a level-2 header_.