### PR TITLE
Add an environment variable to include `bundler`

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -79,7 +79,8 @@ For Windows, there are two main ways to setup your system to be able to render t
 >1. In the File Explorer, right-click on "This PC" icon, and click on
 >   "Properties". Click on "Advanced System Settings", and click on the button
 >   "Environment Variables". Click on the variable "Path", and then the "Edit"
->   button. Click on the "New" button and add `C:\Ruby26-x64\msys64\usr\bin` (use
+>   button. Click on the "New" button and add `C:\Ruby26-x64\msys64\usr\bin` and click "OK".
+>   Click "New" again and add `C:\Ruby26-x64\bin` and click "OK" again. (use
 >   the File Explorer to make sure this is the correct path for your Ruby and
 >   MSYS2 installation). If you're working on R-based lessons and R isn't already
 >   listed there, you need to add it by adding `C:\Program Files\R\R-3.x.x\bin`


### PR DESCRIPTION
On my Windows computer, the `C:\Ruby26-x64\bin` directory contains the primary `ruby.exe` and batch files for running bundler. This was the ONLY environment variable path for Ruby and rendering worked.  For using `make`, the `C:\Ruby26-x64\msys64\mingw64\bin` directory contains `mingw32-make.exe`. I believe the environment variables should include both paths. 

Also, after clicking on "Advanced system settings", one has to choose to edit either "User variables for <localuser>" or "System variables". Both sections have `path` entries. Editing the local user path is identical to the system variables.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
