### PR TITLE
Remove CI

### DIFF
--- a/_includes/carpentries.html
+++ b/_includes/carpentries.html
@@ -21,8 +21,7 @@
     lesson project, The Carpentries provide overall staffing and governance, as
     well as support for assessment, instructor training and mentoring.
     Memberships are joint, and the Carpentries project maintains a shared Code
-    of Conduct. The Carpentries is a fiscally sponsored project of Community
-    Initiatives, a registered 501(c)3 non-profit based in California, USA.</p>
+    of Conduct. The Carpentries is a registered 501(c)3 non-profit based in Delaware, USA.</p>
   </div>
 </div>
 <div class="row">


### PR DESCRIPTION
Remove references to our former fiscal sponsor, Community Initiatives.

Related to carpentries/carpentries.org#364 and carpentries/carpentries.org#363.